### PR TITLE
1C. Apply street/proximity/status scrolling behavior to query results.

### DIFF
--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -345,7 +345,7 @@ MASSGIS.fillOpacity = .7; // opacity of gps point (0 = completely clear, 1 = ful
 								</ul>
 							</div>
 						</section>
-						<div data-role="navbar" id="addr_list_buttons">
+						<div data-role="navbar" id="addr_list_buttons" style="margin-right: 31px;">
 							<ul>
 								<li><a class="ui-btn-active" id="search_street" href="#">By Street</a></li>
 								<li><a id="search_proximity" href="#">By Proximity</a></li>

--- a/htdocs/js/massgis_mft.js
+++ b/htdocs/js/massgis_mft.js
@@ -398,14 +398,8 @@ setTimeout(function() {
 			m && MASSGIS.addressQueryResults.push(feature);
 		});
 
-		//console.log(MASSGIS.addressQueryResults.length + " features found");
-		if (MASSGIS.addressQueryResults.length == 0) {
-			html = "<li style='color: #903'>No Matching Addresses Found</li>";
-		} else {
-			var html = $('#addressListTmpl').render(MASSGIS.addressQueryResults);
-		}
-		$('#addr_query ul').html(html);
-		$('#addr_query ul').listview('refresh');
+		MASSGIS.mqfDrawOffset = 1;
+		MASSGIS.renderQueryResults();
 	});
 
 	$('#settings_clear').on("click",function() {
@@ -1079,6 +1073,27 @@ setTimeout(function() {
 		MASSGIS.map.pan(1,1); // This nudge takes care of Canvas labeling artifacts.
 		MASSGIS.hideModalMessage();
 },100);
+	});
+
+	$('#addr_query_res').on('scroll', function() {
+		if ($(this).scrollTop() === 0) {
+			MASSGIS.mqfDrawOffset = Math.max(1, MASSGIS.mqfDrawOffset - 1);
+			MASSGIS.renderQueryResults();
+			if (MASSGIS.mqfDrawOffset === 1) {
+				$(this).scrollTo(0);
+			} else {
+				$(this).scrollTo('50%');
+			}
+		}
+		if ($(this).scrollTop() + $(this).innerHeight() >= $(this)[0].scrollHeight - 1) {
+			MASSGIS.mqfDrawOffset = Math.min(MASSGIS.mqfDrawOffset + 1, Math.ceil(MASSGIS.addressQueryResults.length / MASSGIS.mqfDrawMultiple));
+			MASSGIS.renderQueryResults();
+			if (MASSGIS.mqfDrawOffset === Math.ceil(MASSGIS.addressQueryResults.length / MASSGIS.mqfDrawMultiple)) {
+				$(this).scrollTo('100%');
+			} else {
+				$(this).scrollTo('50%');
+			}
+		}
 	});
 
 	$('#addr_list > div').on('scroll', function() {
@@ -2127,6 +2142,7 @@ MASSGIS.renderLinkedAddresses = function() {
 
 MASSGIS.mafDrawOffset = 1;
 MASSGIS.mafDrawMultiple = 35;
+MASSGIS.mqfDrawMultiple = 35;
 MASSGIS.buildAddressAutocompletes = function() {
 	MASSGIS.streets_to_street_id_hash = {};
 	MASSGIS.sites_to_site_id_hash = {};
@@ -2159,6 +2175,22 @@ MASSGIS.buildAddressAutocompletes = function() {
 	// });
 	MASSGIS.sites_list = Object.keys(MASSGIS.sites_to_site_id_hash);
 };
+
+MASSGIS.renderQueryResults = function() {
+	//console.log(MASSGIS.addressQueryResults.length + " features found");
+	var html = "<li style='color: #903'>No Matching Addresses Found</li>";
+
+	var mqfDrawAddrList = [];
+	if (MASSGIS.addressQueryResults.length > 0) {
+		for (var i = Math.max(0,(MASSGIS.mqfDrawOffset - 2)) * MASSGIS.mqfDrawMultiple; i < Math.min(MASSGIS.addressQueryResults.length, MASSGIS.mqfDrawMultiple * MASSGIS.mqfDrawOffset); i++) {
+			mqfDrawAddrList.push(MASSGIS.addressQueryResults[i]);
+		}
+		html = $('#addressListTmpl').render(mqfDrawAddrList);
+	}
+
+	$('#addr_query ul').html(html);
+	$('#addr_query ul').listview('refresh');
+}
 
 MASSGIS.renderAddressList = function() {
 	var featuresToList = /street|status/.test(MASSGIS.addressListMode)


### PR DESCRIPTION
I wasn't exactly sure of the var naming convention.  I needed to borrow the logic for something like MASSGIS.mafDrawOffset of address list land to this query result land.  So I guessed the 'a' part of 'maf' was for addrs and turned it into MASSGIS.mqfDrawOffset for query.

Incidentally, I was able to trip up the scrolling of by status to come up w/ a blank list.  It's unrelated to this PR, but I think the root cause is that the street/proximity/status all share the same DOM and want to apply the same fancy scrolling behavior across the board.  But you run into issues because the # of features in each panel aren't the same, so the scrolling offsets get mixed up.

I also scooted the bottom navbar over to keep it consistent w/ the changed top nav bar.

![image](https://user-images.githubusercontent.com/180985/59060521-49a7ec80-886f-11e9-94b0-38e1cb9924cf.png)