### PR TITLE
1D. Show copied addrs in italics.

### DIFF
--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -807,7 +807,7 @@ MASSGIS.fillOpacity = .7; // opacity of gps point (0 = completely clear, 1 = ful
 	<li style="background-color: {{>backgroundColor}}" data-id="{{>id}}" class="full_addr">
 		<span
 			title="{{>attributes.full_number_standardized}} {{>attributes.street_name}} {{>attributes.unit}} {{>attributes.site_name}} {{>attributes.building_name}}"
-			style="display: inline-block; box-shadow: none; width:60%; overflow: hidden; white-space: nowrap;">
+			style="display: inline-block; box-shadow: none; width:60%; overflow: hidden; white-space: nowrap; {{if (attributes.is_copy == 'yes')}} ;font-style:italic {{/if}}">
 			{{>attributes.full_number_standardized}} {{>attributes.street_name}}
 			{{if attributes.building_name}}, B: {{>attributes.building_name}} {{/if}}
 			{{if attributes.unit}}, U: {{>attributes.unit}} {{/if}}

--- a/htdocs/js/massgis_mft.js
+++ b/htdocs/js/massgis_mft.js
@@ -1256,6 +1256,8 @@ setTimeout(function() {
 		f.attributes.transaction_id = MASSGIS.generateTXId();
 		f.attributes.time_stamp = new Date().toTimeString().split(" ")[0];
 		f.attributes.__MODIFIED__ = true;
+		f.attributes.last_edit_comments = 'COPY ' + (f.attributes.last_edit_comments || '').replace(/^COPY /, '');
+		f.attributes.is_copy = 'yes';
 		delete f.fid;
 		MASSGIS.lyr_maf.addFeatures([f]);
 		MASSGIS.lyr_maf.strategies[1].save();
@@ -1768,6 +1770,7 @@ MASSGIS.check_recs_to_submit = function() {
 
 			delete f.attributes.__MODIFIED__;
 			delete f.attributes.bbox;
+			delete f.attributes.is_copy;
 			mafSubmit.push(f);
 		}
 	});
@@ -1783,6 +1786,7 @@ MASSGIS.check_recs_to_submit = function() {
 
 			delete f.attributes.__MODIFIED__;
 			delete f.attributes.bbox;
+			delete f.attributes.is_copy;
 			addrSubmit.push(f);
 		}
 	});
@@ -1819,6 +1823,7 @@ MASSGIS.submit_maf_records = function() {
 
 			delete f.attributes.__MODIFIED__;
 			delete f.attributes.bbox;
+			delete f.attributes.is_copy;
 			mafSubmitFeatures.push(f);
 		}
 	});
@@ -1914,6 +1919,7 @@ MASSGIS.submit_address_points = function() {
 
 			delete f.attributes.__MODIFIED__;
 			delete f.attributes.bbox;
+			delete f.attributes.is_copy;
 			addrSubmitFeatures.push(f);
 		}
 	});


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/180985/59122980-1f673500-892a-11e9-9168-7fa9b459ff46.png)

`is_copy` will not go back over the wire when data is submitted, but it does __not__ get wiped from the browser.  So the italics are preserved until a user pushes data and then pulls down fresh data to replace their local copy (I'm guessing).


![image](https://user-images.githubusercontent.com/180985/59122910-f8a8fe80-8929-11e9-98fd-dd26603d791a.png)